### PR TITLE
Update English.ini

### DIFF
--- a/language/English.ini
+++ b/language/English.ini
@@ -539,8 +539,7 @@ diylogo=Select file
 shutdownmsgbox=Shut down confirmation box
 finderdark=Finder appearance
 showmediacontrol=Displays the media playback icon
-showuseraccount=The account icon is displayed
-
+showuseraccount=Show user accounts icon
 systemtraycolor=Show colored tray icons
 showkeyboard=Show input method menu
 showsearch=Show search icon
@@ -762,7 +761,7 @@ backuptips=Do you want to restore this backup file?
 [menu]
 ;Right menu
 
-RecentFiles=Recently opened files
+RecentFiles=Recent Items
 otheroption=Options
 dockmenu=Program menu
 menurecent=Recently visited
@@ -940,8 +939,8 @@ Reboot=Restart
 Shutdown&Update=Shut down and update
 Reboot&Update=Reboot and update
 
-Lock screen=Lock
-Logout=Log out
+Lock screen=Lock Screen
+Logout=Log Out
 
 symbol=Show emoticons and symbols 
 Screen Keyboard=Show on-screen keyboard


### PR DESCRIPTION
Some options changes on Apple menu: match with macOS   使其与macOS 上的苹果菜单选项名称 相符一样

Recently opened files = Recent Items

Lock = Lock Screen

Log out = Log Out  The letter "O" is capitalized.  字母 “O” 为大写。






My dockfinder settings→ MyFinder→ Look & Behavior: 

"The account icon is displayed" change to " Show user accounts icon" seems better? 

“显示账户图标”的英文描述 有点奇怪